### PR TITLE
feat: add retry to window.Telegram.Webapp

### DIFF
--- a/src/WebAppProvider.tsx
+++ b/src/WebAppProvider.tsx
@@ -60,12 +60,12 @@ const WebAppProvider = ({
   useEffect(() => {
     let retries = 0;
     const timer = setInterval(() => {
+      retries += 1;
       if (window?.Telegram?.WebApp) {
         clearInterval(timer);
         setWebApp(window.Telegram.WebApp);
       }
       if (retries > 4) clearInterval(timer);
-      retries += 1;
     }, 1000);
 
     if (!options?.smoothButtonsTransition) return;


### PR DESCRIPTION
This is a proposal to add a wait and retry functionality when window.Telegram.Webapp is still not initialized.

The motivation was that I've faced this issue when using Next.js 14 with app router.  In this case, the Webapp object was always undefined.
After trying many options, the only solution that I've found that worked for me was to give some more time to get the object. I've tested, and the library is working as normal with that modification.

If that solution is not liked, another possible solution would be to expose the setWebapp method to be able to do the retry by myself outside the library. But in general, I think that this little change can make the library more robust, as the retry won't be executed at all if it is not needed.

Also, would be possible to set the retry count as parameter, but I'm feeling like overcomplicating because for me 1 retry works fine and giving 5 retry max (5 seconds) is more than enough in any case and nothing to worry about performance.

In case is desired, further investigation of the root cause of the issue I am available to get in contact and to test locally I think that probably creating a basic next.js 14 application using app router should be enough to replicate the issue.

Anyway, if there is at least 1 situation that this could happen, I think that would be good for the library to be able to manage the situation by itself.

